### PR TITLE
minor correction to detection of NEC devices

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -1929,7 +1929,7 @@ M.T.T.:
 
 # nec
 NEC:
-  regex: 'NEC|KGT/2\.0|portalmmm/1\.0 (?:DB|N)|(?:portalmmm|o2imode)/2.0[ ,]N'
+  regex: 'NEC-|KGT/2\.0|portalmmm/1\.0 (?:DB|N)|(?:portalmmm|o2imode)/2.0[ ,]N'
   device: 'smartphone'
   models:
     - regex: '(?:NEC-|KGT/2\.0 )([a-z0-9]+)'


### PR DESCRIPTION
It also prevents user agents containing e.g. "OfficeLiveConnector.1.3" to be wrongly detected as Nec.
